### PR TITLE
Remove shared Core project

### DIFF
--- a/InputMappingSolution.sln
+++ b/InputMappingSolution.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputToControllerMapper", "InputToControllerMapper\InputToControllerMapper.csproj", "{4E4BAA4A-FE7E-4F5A-80EB-4E6E90722663}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4E4BAA4A-FE7E-4F5A-80EB-4E6E90722663}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E4BAA4A-FE7E-4F5A-80EB-4E6E90722663}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E4BAA4A-FE7E-4F5A-80EB-4E6E90722663}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E4BAA4A-FE7E-4F5A-80EB-4E6E90722663}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/InputToControllerMapper/ApplicationConfiguration.cs
+++ b/InputToControllerMapper/ApplicationConfiguration.cs
@@ -1,0 +1,14 @@
+using System.Windows.Forms;
+
+namespace InputToControllerMapper;
+
+internal static class ApplicationConfiguration
+{
+    // Mimics the WinForms template initialization to set default font and high DPI mode.
+    public static void Initialize()
+    {
+        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+    }
+}

--- a/InputToControllerMapper/InputToControllerMapper.csproj
+++ b/InputToControllerMapper/InputToControllerMapper.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+
+  <!--
+    Copy all native DLLs from the solution-wide 'native_sdks' folder
+    into this project's output directory after every build.
+  -->
+  <ItemGroup>
+    <NativeDlls Include="$(SolutionDir)native_sdks\*.dll" />
+  </ItemGroup>
+
+  <Target Name="CopyNativeSdks" AfterTargets="Build">
+    <Copy SourceFiles="@(NativeDlls)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/InputToControllerMapper/MainForm.cs
+++ b/InputToControllerMapper/MainForm.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+// Wooting SDK P/Invoke definitions are in WootingAnalog.cs
+
+namespace InputToControllerMapper;
+
+public class MainForm : Form
+{
+    private readonly TextBox _logBox;
+    private readonly System.Windows.Forms.Timer _analogTimer;
+
+    // Win32 constants
+    private const int WM_INPUT = 0x00FF;
+    private const uint RIDEV_INPUTSINK = 0x00000100;
+    private const uint RID_INPUT = 0x10000003;
+    private static readonly uint RAWINPUTHEADER_SIZE = (uint)Marshal.SizeOf<RAWINPUTHEADER>();
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RAWINPUTDEVICE
+    {
+        public ushort usUsagePage;
+        public ushort usUsage;
+        public uint dwFlags;
+        public IntPtr hwndTarget;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RAWINPUTHEADER
+    {
+        public uint dwType;
+        public uint dwSize;
+        public IntPtr hDevice;
+        public IntPtr wParam;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RAWMOUSE
+    {
+        public ushort usFlags;
+        public uint ulButtons;
+        public ushort usButtonFlags;
+        public ushort usButtonData;
+        public uint ulRawButtons;
+        public int lLastX;
+        public int lLastY;
+        public uint ulExtraInformation;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RAWINPUT
+    {
+        public RAWINPUTHEADER header;
+        public RAWMOUSE mouse;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool RegisterRawInputDevices(RAWINPUTDEVICE[] pRawInputDevices, uint uiNumDevices, uint cbSize);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint GetRawInputData(IntPtr hRawInput, uint uiCommand, IntPtr pData, ref uint pcbSize, uint cbSizeHeader);
+
+    public MainForm()
+    {
+        Text = "Input Logger";
+        Width = 800;
+        Height = 600;
+
+        _logBox = new TextBox
+        {
+            Multiline = true,
+            Dock = DockStyle.Fill,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Vertical
+        };
+        Controls.Add(_logBox);
+
+        _analogTimer = new System.Windows.Forms.Timer { Interval = 50 };
+        _analogTimer.Tick += AnalogTimer_Tick;
+        _analogTimer.Start();
+
+        // Initialize Wooting SDK
+        try
+        {
+            WootingAnalog.wooting_analog_initialise();
+        }
+        catch (DllNotFoundException ex)
+        {
+            Log($"Wooting SDK DLL not found: {ex.Message}");
+        }
+
+        RegisterForRawMouse();
+    }
+
+    private void AnalogTimer_Tick(object? sender, EventArgs e)
+    {
+        // Example: read analog value for the "W" key (HID usage ID 0x1A)
+        float value = 0f;
+        try
+        {
+            value = WootingAnalog.wooting_analog_read_full(0x1A);
+        }
+        catch (Exception ex)
+        {
+            Log($"Analog read failed: {ex.Message}");
+        }
+
+        Log($"Analog W: {value:F3}");
+    }
+
+    private void RegisterForRawMouse()
+    {
+        RAWINPUTDEVICE[] rid = new[]
+        {
+            new RAWINPUTDEVICE
+            {
+                usUsagePage = 0x01, // Generic desktop controls
+                usUsage = 0x02,     // Mouse
+                dwFlags = RIDEV_INPUTSINK,
+                hwndTarget = Handle
+            }
+        };
+
+        if (!RegisterRawInputDevices(rid, (uint)rid.Length, (uint)Marshal.SizeOf<RAWINPUTDEVICE>()))
+        {
+            Log($"RegisterRawInputDevices failed with error {Marshal.GetLastWin32Error()}");
+        }
+    }
+
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == WM_INPUT)
+        {
+            uint dwSize = 0;
+            // First call to obtain the required buffer size
+            GetRawInputData(m.LParam, RID_INPUT, IntPtr.Zero, ref dwSize, RAWINPUTHEADER_SIZE);
+            if (dwSize > 0)
+            {
+                IntPtr buffer = Marshal.AllocHGlobal((int)dwSize);
+                try
+                {
+                    if (GetRawInputData(m.LParam, RID_INPUT, buffer, ref dwSize, RAWINPUTHEADER_SIZE) == dwSize)
+                    {
+                        RAWINPUT raw = Marshal.PtrToStructure<RAWINPUT>(buffer);
+                        Log($"Mouse: X={raw.mouse.lLastX} Y={raw.mouse.lLastY}");
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+        }
+        base.WndProc(ref m);
+    }
+
+    private void Log(string message)
+    {
+        _logBox.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
+    }
+}

--- a/InputToControllerMapper/Program.cs
+++ b/InputToControllerMapper/Program.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Windows.Forms;
+
+namespace InputToControllerMapper;
+
+internal static class Program
+{
+    /// <summary>
+    ///  The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    static void Main()
+    {
+        ApplicationConfiguration.Initialize();
+        Application.Run(new MainForm());
+    }
+}

--- a/InputToControllerMapper/WootingAnalog.cs
+++ b/InputToControllerMapper/WootingAnalog.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace InputToControllerMapper;
+
+/// <summary>
+/// Provides P/Invoke declarations for the Wooting Analog SDK.
+/// Only the minimal functions required for polling analog values are defined.
+/// The native DLL (wooting_analog_wrapper.dll) must reside in the application directory.
+/// </summary>
+public static class WootingAnalog
+{
+    /// <summary>
+    /// Initializes communication with the Wooting keyboard.
+    /// </summary>
+    [DllImport("wooting_analog_wrapper.dll", CallingConvention = CallingConvention.Cdecl)]
+    public static extern bool wooting_analog_initialise();
+
+    /// <summary>
+    /// Returns the analog value for the provided keycode.
+    /// Keycodes are based on the HID usage ID.
+    /// </summary>
+    [DllImport("wooting_analog_wrapper.dll", CallingConvention = CallingConvention.Cdecl)]
+    public static extern float wooting_analog_read_full(int keycode);
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Input Mapping Solution
+
+A .NET 9 solution to log mouse and Wooting analog keyboard input using a WinForms app and the Wooting SDK.
+
+## Prerequisites
+- .NET 9 SDK: install from [dotnet.microsoft.com](https://dotnet.microsoft.com/download/dotnet/9.0) and verify with `dotnet --version`.
+- Windows 10/11 is required for the Raw Input API and Wooting SDK.
+- Wooting Analog SDK: see `SDK-PLUGINS.txt` for download links and instructions.
+
+## Solution Structure
+- `InputMappingSolution.sln` – solution file.
+- `InputToControllerMapper/` – WinForms logger with embedded Wooting SDK P/Invoke code.
+  - `MainForm.cs`
+  - `WootingAnalog.cs`
+  - `ApplicationConfiguration.cs`
+  - `Program.cs`
+  - `InputToControllerMapper.csproj` (copies DLLs).
+- `native_sdks/` – drop all native DLLs here (initially empty).
+- `SDK-PLUGINS.txt` – SDK setup and troubleshooting guide.
+- `README.md` – this file.
+
+## Getting Started
+1. Install the .NET 9 SDK.
+2. Download the Wooting Analog SDK and place `wooting_analog_wrapper.dll` in `native_sdks`.
+3. Build the solution with `dotnet build` or open it in Visual Studio.
+4. Run the `InputToControllerMapper` project and watch the textbox for mouse and analog keyboard logs.
+5. If you migrated from an older version that used a shared Core library, run `./remove_core.sh` to clean up residual references.
+
+## Troubleshooting
+If input events or the SDK fail to load, review `SDK-PLUGINS.txt` for hints about DLL placement and architecture.
+
+## Note
+The WinForms application requires the **Microsoft.WindowsDesktop.App** runtime, which is only available on Windows 10/11. You can build on Linux using `dotnet build -p:EnableWindowsTargeting=true`, but running the app must be done on Windows.

--- a/SDK-PLUGINS.txt
+++ b/SDK-PLUGINS.txt
@@ -1,0 +1,16 @@
+Wooting SDK Instructions
+-----------------------
+
+1. Download the **Wooting Analog SDK** from [https://github.com/WootingKb/wooting-analog-sdk](https://github.com/WootingKb/wooting-analog-sdk).
+   - Extract `wooting_analog_wrapper.dll` from the release package matching the bitness of your application (x64 recommended).
+
+2. Copy `wooting_analog_wrapper.dll` into the `native_sdks` folder at the root of this repository.
+   - Any additional native plugins should also be placed here in the future.
+
+3. Build the solution. All `*.dll` files found in `native_sdks` will be automatically copied to each project's output directory.
+
+Troubleshooting
+---------------
+- Ensure the DLLs are **unblocked** on Windows (right-click > Properties > Unblock).
+- The DLL architecture must match your build target (x64).
+- If the application fails to load the SDK, confirm the file exists in the output directory next to the executable.

--- a/remove_core.sh
+++ b/remove_core.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Removes the shared Core project and migrates its code into InputToControllerMapper.
+# Run from the solution root.
+set -e
+solution="InputMappingSolution.sln"
+core_project="Core/Core.csproj"
+target_dir="InputToControllerMapper"
+
+# Move code files if the Core directory exists
+if [ -d "Core" ]; then
+    mv Core/*.cs "$target_dir/" || true
+    rm -rf Core
+fi
+
+# Remove project reference from the solution
+if command -v dotnet >/dev/null 2>&1; then
+    dotnet sln "$solution" remove "$core_project" 2>/dev/null || true
+fi
+
+# Purge project references from csproj files
+find . -name "*.csproj" -exec sed -i '/Core\\\\Core.csproj/d' {} +
+
+# Clean up using statements referencing Core
+grep -rl "using Core;" "$target_dir" | xargs sed -i 's/^using Core;\s*//'
+
+echo "Core project removed."


### PR DESCRIPTION
## Summary
- drop the Core class library so each app is self-contained
- inline WootingAnalog.cs into InputToControllerMapper and update namespaces
- clean up project and solution references to Core
- document the new structure and add a helper script to repeat the cleanup
- mention cleanup script in README

## Testing
- ❌ `dotnet build InputMappingSolution.sln -c Release` (failed: `dotnet` not found)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68697a1bb1288320aa0bc3a5ee191ec5